### PR TITLE
NO-JIRA: Add cflag: -I/opt/homebrew/opt/heimdal/include

### DIFF
--- a/name.go
+++ b/name.go
@@ -16,9 +16,10 @@ package gssapi
 //
 // Using "MacPorts" on MacOS gives us: -I/opt/local/include
 // Using "brew" on MacOS gives us: -I/usr/local/opt/heimdal/include
+// Using "brew" on MacOS (Apple Silicon) gives us: -I/opt/homebrew/opt/heimdal/include
 
 /*
-#cgo darwin CFLAGS: -I/opt/local/include -I/usr/local/opt/heimdal/include
+#cgo darwin CFLAGS: -I/opt/local/include -I/usr/local/opt/heimdal/include -I/opt/homebrew/opt/heimdal/include
 #include <stdio.h>
 
 #include <gssapi/gssapi.h>


### PR DESCRIPTION
This is needed on Apple Silicon, where the include path when using Homebrew is different.

Required in the end for https://github.com/openshift/oc/pull/2246#discussion_r3032465023